### PR TITLE
Fix: Change submitScore parameter from Int to Long to support large scores

### DIFF
--- a/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/GodotAndroidPlugin.kt
+++ b/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/GodotAndroidPlugin.kt
@@ -213,7 +213,7 @@ class GodotAndroidPlugin(godot: Godot) : GodotPlugin(godot) {
      * @param score The raw score value. For more details, please [see this page](https://developers.google.com/games/services/common/concepts/leaderboards).
      */
     @UsedByGodot
-    fun submitScore(leaderboardId: String, score: Int) =
+    fun submitScore(leaderboardId: String, score: Long) =
         leaderboardsProxy.submitScore(leaderboardId, score)
 
     /**

--- a/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/leaderboards/LeaderboardsProxy.kt
+++ b/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/leaderboards/LeaderboardsProxy.kt
@@ -92,9 +92,9 @@ class LeaderboardsProxy(
             }
     }
 
-    fun submitScore(leaderboardId: String, score: Int) {
+    fun submitScore(leaderboardId: String, score: Long) {
         Log.d(tag, "Submitting score of $score to leaderboard $leaderboardId")
-        leaderboardsClient.submitScoreImmediate(leaderboardId, score.toLong())
+        leaderboardsClient.submitScoreImmediate(leaderboardId, score)
             .addOnCompleteListener { task ->
                 if (task.isSuccessful) {
                     Log.d(tag, "Score submitted successfully")


### PR DESCRIPTION
## Problem
The `submitScore` function uses `Int` (32-bit) for the score parameter, which overflows for scores larger than 2.1 billion. Google Play Games Services supports 64-bit scores via `Long`.

## Solution
- Changed `submitScore(leaderboardId: String, score: Int)` to `submitScore(leaderboardId: String, score: Long)` in `LeaderboardsProxy.kt`
- Updated the signal bridge in `GodotAndroidPlugin.kt` to use `Long` instead of `Int`
- Removed unnecessary `.toLong()` conversion

## Testing
Tested with scores in the trillions (e.g., 2,000,000,000,000) and they now submit correctly to Google Play leaderboards without overflow.

## Real-world use case
Our game encodes level, time, and optimal time into a single score using the formula:
`level * 10^12 + (999999 - seconds) * 10^6 + optimal_seconds`

This creates scores that easily exceed 2 billion for any level > 1, causing Int overflow.

## Breaking Changes
None - this is a compatible type widening. Int values still work with Long parameters.