### PR TITLE
Update README.adoc

### DIFF
--- a/plugin/demo/README.adoc
+++ b/plugin/demo/README.adoc
@@ -26,7 +26,7 @@ Finally, you can not run the game as a normal game. Instead, you have to run it 
 == First time opening the demo project
 The first time you open the demo project, you will see this error in the Godot editor:
 
-image::demo_project_error.png[alt="Screenshot of an error in the Godot editor that says:\"Failed to load script \"res://scenes/MainMenu.gd\" with error \"Parse Error\".",title=Error loading script at first run of the project.,width=298,align=center]
+image::demo_project_error.png[alt="Screenshot of an error in the Godot editor that says:\"Failed to load script \"res://scenes/MainMenu.gd\" with error \"Parse Error\".",title=Error loading script at first run of the project.,width=596,align=center]
 
 This is completely normal, because the plugin is not yet activated. Simply go to `Project > Project Settings > Plugins` and enable the plugin, which should appear there if you have installed it in the `addons` folder.
 


### PR DESCRIPTION
Fix incorrect image syntax for the error message

Before: 
<img width="675" height="211" alt="image" src="https://github.com/user-attachments/assets/c245d170-a750-408b-96c4-7c0f5efec002" />

After:
<img width="682" height="182" alt="image" src="https://github.com/user-attachments/assets/043b6697-4919-4914-8b37-873be876c00c" />
