### PR TITLE
Add new function set_achievement_steps

### DIFF
--- a/plugin/export_scripts_template/scripts/achievements/achievements_client.gd
+++ b/plugin/export_scripts_template/scripts/achievements/achievements_client.gd
@@ -93,3 +93,15 @@ func show_achievements() -> void:
 func unlock_achievement(achievement_id: String) -> void:
 	if GodotPlayGameServices.android_plugin:
 		GodotPlayGameServices.android_plugin.unlockAchievement(achievement_id)
+
+## Immediately set the given achievement for the signed in player to have at least the given number of steps completed.[br]
+## Calling this method when the achievement already has more than the provided steps is a no-op.[br]
+## Once the achievement reaches the maximum number of steps, the achievement will automatically be unlocked, and any further mutation operations will be ignored.
+## [br]
+## The method emits the [signal achievement_unlocked] signal.[br]
+## [br]
+## [param achievement_id]: The achievement id.[br]
+## [param num_steps]: The number of steps to set the achievement to. Must be greater than 0.
+func set_achievement_steps(achievement_id: String, num_steps: int) -> void:
+	if GodotPlayGameServices.android_plugin:
+		GodotPlayGameServices.android_plugin.setAchievementSteps(achievement_id, num_steps)

--- a/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/GodotAndroidPlugin.kt
+++ b/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/GodotAndroidPlugin.kt
@@ -164,6 +164,19 @@ class GodotAndroidPlugin(godot: Godot) : GodotPlugin(godot) {
         achievementsProxy.unlockAchievement(achievementId)
 
     /**
+     * Use this method to set a given achievement to have at least the given amount of steps completed. For normal achievements,
+     * use the [unlockAchievement] method instead.
+     *
+     * The method emits the [com.jacobibanez.plugin.android.godotplaygameservices.signals.AchievementsSignals.achievementUnlocked] signal.
+     *
+     * @param achievementId The achievement id.
+     * @param numSteps The number of steps to set the achievement to. Must be greater than 0.
+     */
+    @UsedByGodot
+    fun setAchievementSteps(achievementId: String, numSteps: Int) =
+        achievementsProxy.setAchievementSteps(achievementId, numSteps)
+
+    /**
      * Shows a new screen with all the leaderboards for the game.
      */
     @UsedByGodot

--- a/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/achievements/AchievementsProxy.kt
+++ b/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/achievements/AchievementsProxy.kt
@@ -161,7 +161,7 @@ class AchievementsProxy(
 
     fun setAchievementSteps(achievementId: String, numSteps: Int) {
         Log.d(tag, "Setting incremental achievement with id $achievementId to $numSteps steps")
-        achievementsClient.setStepsImmediate(achievementId, amount).addOnCompleteListener { task ->
+        achievementsClient.setStepsImmediate(achievementId, numSteps).addOnCompleteListener { task ->
             if (task.isSuccessful) {
                 Log.d(
                     tag,

--- a/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/achievements/AchievementsProxy.kt
+++ b/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/achievements/AchievementsProxy.kt
@@ -158,4 +158,36 @@ class AchievementsProxy(
             }
         }
     }
+
+    fun setAchievementSteps(achievementId: String, numSteps: Int) {
+        Log.d(tag, "Setting incremental achievement with id $achievementId to $numSteps steps")
+        achievementsClient.setStepsImmediate(achievementId, amount).addOnCompleteListener { task ->
+            if (task.isSuccessful) {
+                Log.d(
+                    tag,
+                    "Achievement steps for $achievementId set successfully. Unlocked? ${task.result}"
+                )
+                emitSignal(
+                    godot,
+                    BuildConfig.GODOT_PLUGIN_NAME,
+                    achievementUnlocked,
+                    task.result,
+                    achievementId
+                )
+            } else {
+                Log.e(
+                    tag,
+                    "Achievement steps for $achievementId not set. Cause: ${task.exception}",
+                    task.exception
+                )
+                emitSignal(
+                    godot,
+                    BuildConfig.GODOT_PLUGIN_NAME,
+                    achievementUnlocked,
+                    false,
+                    achievementId
+                )
+            }
+        }
+    }
 }

--- a/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/signals/Signals.kt
+++ b/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/signals/Signals.kt
@@ -59,8 +59,9 @@ object SignInSignals {
  */
 object AchievementsSignals {
     /**
-     * This signal is emitted when calling the [com.jacobibanez.plugin.android.godotplaygameservices.GodotAndroidPlugin.incrementAchievement]
-     * or [com.jacobibanez.plugin.android.godotplaygameservices.GodotAndroidPlugin.unlockAchievement] methods.
+     * This signal is emitted when calling the [com.jacobibanez.plugin.android.godotplaygameservices.GodotAndroidPlugin.incrementAchievement],
+     * [com.jacobibanez.plugin.android.godotplaygameservices.GodotAndroidPlugin.unlockAchievement] 
+     * or [com.jacobibanez.plugin.android.godotplaygameservices.GodotAndroidPlugin.setAchievementSteps] methods.
      *
      * @return `true` if the achievement is unlocked. `false` otherwise. Also returns the id of the achievement.
      */


### PR DESCRIPTION
~~Note, this is untested, since I'm stuck unable to sign in as mentioned in #98~~

I've been trying to implement the plugin blindly while the sign in issue is unresolved, and when I was reading Google's documentation I found a method that would be very handy for us given how our existing achievement data is setup: https://developers.google.com/android/reference/com/google/android/gms/games/AchievementsClient#setStepsImmediate(java.lang.String,%20int)

I used to be a native app developer (although in iOS), so I figured I could try making a quick PR.

I'm not 100% certain if this compiles or works (😬), but I copied existing functionality and made the minor tweaks I think are needed. I also tried updating all relevant documentation I could find.