### PR TITLE
docs: clarify macOS addon extraction path

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ If you want to contribute, please read the [CONTRIBUTING.md](CONTRIBUTING.md) fi
 ```
 [Project root]/addons/GodotPlayGameServices/
 ```
+On macOS, Safari may automatically extract `addons.zip` into a `GodotPlayGameServices` folder. If that happens, create an `addons` folder in your project root if it does not exist, then move the extracted `GodotPlayGameServices` folder inside it so the final path still matches the structure above.
 3. Open your project in Godot.
 4. In main menu, go to `Project > Project Settings > Plugins`, and enable **GodotPlayGameServices**.
 

--- a/plugin/demo/README.adoc
+++ b/plugin/demo/README.adoc
@@ -7,7 +7,7 @@ Doc Writer <jacobibanez@jacobibanez.com>
 
 This folder is a Godot project that you can directly open in Godot to see an implementation of the plugin in a real Godot game.
 
-IMPORTANT: To use this project, you have to uncompress the contents of the `addons.zip` file in the link:https://github.com/Iakobs/godot-play-game-services/releases[releases section] of the repository to the root folder of the project. Alternatively, you can run the `./gradlew assemble` command from the root of the repository. This command will install the plugin in the `addons` directory of the godot project.
+IMPORTANT: To use this project, you have to uncompress the contents of the `addons.zip` file in the link:https://github.com/godot-sdk-integrations/godot-play-game-services/releases[releases section] of the repository to the root folder of the project. The final path should be `plugin/demo/addons/GodotPlayGameServices`. If macOS automatically extracts the zip into a `GodotPlayGameServices` folder, move that folder into `plugin/demo/addons/` instead of leaving it beside the `addons` folder. Alternatively, you can run the `./gradlew assemble` command from the root of the repository. This command will install the plugin in the `addons` directory of the godot project.
 
 == Directory Structure
 The demo project contains a `scenes` folder with all the `.tscn` and `.gd` files that you will need, everything is inside this folder.


### PR DESCRIPTION
## Summary
- clarify that macOS/Safari may auto-extract `addons.zip` into `GodotPlayGameServices`
- spell out that the extracted folder still needs to live at `addons/GodotPlayGameServices`
- update the demo README release link to the current organization while clarifying the expected demo path

Closes #95

## Validation
- `git diff --check`

Note: the GitHub release instructions mentioned in the issue are not source-controlled in this repository, so this PR updates the repo-owned install docs.