### PR TITLE
fix: rename Play Games Services plugin identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ If you want to contribute, please read the [CONTRIBUTING.md](CONTRIBUTING.md) fi
 1. Download the latest release from the [Godot Asset Store](https://store-beta.godotengine.org/asset/jacob-ibanez-sanchez/google-play-games-services-for-godot/) or the [GitHub releases](https://github.com/godot-sdk-integrations/godot-play-game-services/releases).
 2. Extract and copy the plugin to your project's `addons` folder. The final structure should look like:
 ```
-[Project root]/addons/GodotPlayGameServices/
+[Project root]/addons/GodotPlayGamesServices/
 ```
 3. Open your project in Godot.
-4. In main menu, go to `Project > Project Settings > Plugins`, and enable **GodotPlayGameServices**.
+4. In main menu, go to `Project > Project Settings > Plugins`, and enable **GodotPlayGamesServices**.
 
 ## Philosophy of the plugin
 This plugin has been revamped since version 3.0. Before, the plugin created several autoloads, one per each feature of the Play Games API (sign in, leaderboards, snapshots, etc.). Now the plugin follows the Godot philosophy of using Nodes, therefore the autoloads have been converted to Nodes, except the main `GodotPlayGamesServices` one, which now requires manual initialization. The Sign-In flow has been also changed so now the plugin doesn't make an automatic authentication check.
@@ -73,7 +73,7 @@ After making your changes, or if you just want to manually build the plugin, fol
 ```
 ./gradlew assemble
 ```
-The output files can be found in [`plugin/demo/addons`](plugin/demo/addons). The plugin itself, that you can copy to your project to use, is in the [`plugin/demo/addons/GodotPlayGameServices`](plugin/demo/addons/GodotPlayGameServices), just copy the whole `GodotPlayGameServices` folder into the `addons` folder of your Godot project and activate the plugin in `Project` -> `Project Settings...` -> `Plugins`
+The output files can be found in [`plugin/demo/addons`](plugin/demo/addons). The plugin itself, that you can copy to your project to use, is in the [`plugin/demo/addons/GodotPlayGamesServices`](plugin/demo/addons/GodotPlayGamesServices), just copy the whole `GodotPlayGamesServices` folder into the `addons` folder of your Godot project and activate the plugin in `Project` -> `Project Settings...` -> `Plugins`
 
 ### Testing the plugin
 You can also use the included [Godot demo project](plugin/demo) to test the built Android plugin.

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
 }
 
-val pluginName = "GodotPlayGameServices"
+val pluginName = "GodotPlayGamesServices"
 
 val pluginPackageName = "com.jacobibanez.plugin.android.godotplaygameservices"
 

--- a/plugin/demo/README.adoc
+++ b/plugin/demo/README.adoc
@@ -33,7 +33,7 @@ This is completely normal, because the plugin is not yet activated. Simply go to
 After enabling the plugin, confirm that the `GodotPlayGamesServices` autoload appears in the `Autoload` tab. Then simply reload your project from `Project > Reload Current Project`, and you are good to go!
 
 == Initializing the plugin
-You have to manually initialize the plugin calling the `GodotPlayGameServices.initialize()` method of the plugin autoload. The Main Menu of the demo game calls it in the `_enter_tree` virtual method.
+You have to manually initialize the plugin calling the `GodotPlayGamesServices.initialize()` method of the plugin autoload. The Main Menu of the demo game calls it in the `_enter_tree` virtual method.
 
 It uses this method instead of the `_ready` method because this scene also uses the Sign In client, and the plugin needs to be initialized before the clients are loaded into the Scene Tree.
 

--- a/plugin/demo/project.godot
+++ b/plugin/demo/project.godot
@@ -22,7 +22,7 @@ config/icon="res://icon.svg"
 
 [autoload]
 
-GodotPlayGameServices="*res://addons/GodotPlayGameServices/scripts/autoloads/godot_play_game_services.gd"
+GodotPlayGamesServices="*res://addons/GodotPlayGamesServices/scripts/autoloads/godot_play_game_services.gd"
 
 [display]
 
@@ -35,7 +35,7 @@ window/handheld/orientation=1
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/GodotPlayGameServices/plugin.cfg")
+enabled=PackedStringArray("res://addons/GodotPlayGamesServices/plugin.cfg")
 
 [file_customization]
 

--- a/plugin/demo/scenes/MainMenu.gd
+++ b/plugin/demo/scenes/MainMenu.gd
@@ -9,10 +9,10 @@ extends Control
 @onready var play_games_sign_in_client: PlayGamesSignInClient = %PlayGamesSignInClient
 
 func _enter_tree() -> void:
-	GodotPlayGameServices.initialize()
+	GodotPlayGamesServices.initialize()
 
 func _ready() -> void:
-	if not GodotPlayGameServices.android_plugin:
+	if not GodotPlayGamesServices.android_plugin:
 		title_label.text = "Plugin Not Found!"
 	else:
 		title_label.text = "Main Menu"

--- a/plugin/demo/scenes/MainMenu.tscn
+++ b/plugin/demo/scenes/MainMenu.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://bu7jdwk3ndbg6" path="res://scenes/MainMenu.gd" id="1_smv14"]
 [ext_resource type="Theme" uid="uid://bmm3mvq11y045" path="res://theme.tres" id="2_aajnr"]
-[ext_resource type="Script" uid="uid://d0c7icjnmf7ya" path="res://addons/GodotPlayGameServices/scripts/sign_in/sign_in_client.gd" id="3_32bum"]
+[ext_resource type="Script" uid="uid://d0c7icjnmf7ya" path="res://addons/GodotPlayGamesServices/scripts/sign_in/sign_in_client.gd" id="3_32bum"]
 
 [node name="MainMenu" type="Control"]
 layout_mode = 3

--- a/plugin/demo/scenes/achievements/AchievementDisplay.gd
+++ b/plugin/demo/scenes/achievements/AchievementDisplay.gd
@@ -99,7 +99,7 @@ func _connect_signals() -> void:
 					_waiting = false
 					_set_up_display()
 	)
-	GodotPlayGameServices.image_stored.connect(func(file_path: String):
+	GodotPlayGamesServices.image_stored.connect(func(file_path: String):
 		if file_path == play_games_achievement.revealed_image_uri\
 		or file_path == play_games_achievement.unlocked_image_uri:
 			_set_up_icon()
@@ -119,7 +119,7 @@ func _set_up_icon() -> void:
 			property = play_games_achievement.unlocked_image_uri
 	
 	if property and not property.is_empty():
-		GodotPlayGameServices.display_image_in_texture_rect(
+		GodotPlayGamesServices.display_image_in_texture_rect(
 			icon_rect,
 			property
 		)

--- a/plugin/demo/scenes/achievements/Achievements.tscn
+++ b/plugin/demo/scenes/achievements/Achievements.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Theme" uid="uid://bmm3mvq11y045" path="res://theme.tres" id="1_a4mr7"]
 [ext_resource type="Script" path="res://scenes/achievements/Achievements.gd" id="1_h3sdc"]
-[ext_resource type="Script" path="res://addons/GodotPlayGameServices/scripts/achievements/achievements_client.gd" id="3_cmfbe"]
+[ext_resource type="Script" path="res://addons/GodotPlayGamesServices/scripts/achievements/achievements_client.gd" id="3_cmfbe"]
 
 [node name="Achievements" type="Control"]
 layout_mode = 3

--- a/plugin/demo/scenes/leaderboards/LeaderboardDisplay.gd
+++ b/plugin/demo/scenes/leaderboards/LeaderboardDisplay.gd
@@ -27,9 +27,9 @@ var _selected_collection: PlayGamesLeaderboardVariant.Collection
 
 func _ready() -> void:
 	if play_games_leaderboard:
-		GodotPlayGameServices.image_stored.connect(func(file_path: String):
+		GodotPlayGamesServices.image_stored.connect(func(file_path: String):
 			if file_path == play_games_leaderboard.icon_image_uri:
-				GodotPlayGameServices.display_image_in_texture_rect(
+				GodotPlayGamesServices.display_image_in_texture_rect(
 					icon_rect,
 					file_path
 				)

--- a/plugin/demo/scenes/leaderboards/Leaderboards.tscn
+++ b/plugin/demo/scenes/leaderboards/Leaderboards.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://scenes/leaderboards/Leaderboards.gd" id="1_gf0nl"]
 [ext_resource type="Theme" uid="uid://bmm3mvq11y045" path="res://theme.tres" id="1_r8adt"]
-[ext_resource type="Script" path="res://addons/GodotPlayGameServices/scripts/leaderboards/leaderboards_client.gd" id="3_vug45"]
+[ext_resource type="Script" path="res://addons/GodotPlayGamesServices/scripts/leaderboards/leaderboards_client.gd" id="3_vug45"]
 
 [node name="Leaderboards" type="Control"]
 layout_mode = 3

--- a/plugin/demo/scenes/players/PlayerDisplay.gd
+++ b/plugin/demo/scenes/players/PlayerDisplay.gd
@@ -22,7 +22,7 @@ func _ready() -> void:
 		)
 
 func _set_up_display() -> void:
-	GodotPlayGameServices.image_stored.connect(func(file_path: String):
+	GodotPlayGamesServices.image_stored.connect(func(file_path: String):
 		if file_path == play_games_player.hi_res_image_uri and not avatar_rect.texture:
 			_display_avatar()
 	)
@@ -50,7 +50,7 @@ func _load_and_retry(image_uri: String) -> Image:
 	return image
 
 func _display_avatar() -> void:
-	GodotPlayGameServices.display_image_in_texture_rect(
+	GodotPlayGamesServices.display_image_in_texture_rect(
 		avatar_rect,
 		play_games_player.hi_res_image_uri
 	)

--- a/plugin/demo/scenes/players/Players.tscn
+++ b/plugin/demo/scenes/players/Players.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Theme" uid="uid://bmm3mvq11y045" path="res://theme.tres" id="1_i7feq"]
 [ext_resource type="Script" path="res://scenes/players/Players.gd" id="2_xda1v"]
-[ext_resource type="Script" path="res://addons/GodotPlayGameServices/scripts/players/players_client.gd" id="3_ldpls"]
+[ext_resource type="Script" path="res://addons/GodotPlayGamesServices/scripts/players/players_client.gd" id="3_ldpls"]
 
 [node name="Players" type="Control"]
 layout_mode = 3

--- a/plugin/demo/scenes/snapshots/Snapshots.tscn
+++ b/plugin/demo/scenes/snapshots/Snapshots.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Theme" uid="uid://bmm3mvq11y045" path="res://theme.tres" id="1_uo6wb"]
 [ext_resource type="Script" path="res://scenes/snapshots/Snapshots.gd" id="2_cdwya"]
-[ext_resource type="Script" path="res://addons/GodotPlayGameServices/scripts/snapshots/snapshots_client.gd" id="3_xn4op"]
+[ext_resource type="Script" path="res://addons/GodotPlayGamesServices/scripts/snapshots/snapshots_client.gd" id="3_xn4op"]
 
 [node name="Snapshots" type="Control"]
 layout_mode = 3

--- a/plugin/export_scripts_template/export_plugin.gd
+++ b/plugin/export_scripts_template/export_plugin.gd
@@ -1,7 +1,7 @@
 @tool
 extends EditorPlugin
 
-const PLUGIN_AUTOLOAD := &"GodotPlayGameServices"
+const PLUGIN_AUTOLOAD := &"GodotPlayGamesServices"
 
 var _export_plugin : AndroidExportPlugin
 var _dock : Node
@@ -26,7 +26,7 @@ func _remove_plugin() -> void:
 
 func _add_docks() -> void:
 	var dock_name := &"Godot Play Game Services"
-	_dock = preload("res://addons/GodotPlayGameServices/godot_play_game_services_dock.tscn").instantiate()
+	_dock = preload("res://addons/GodotPlayGamesServices/godot_play_game_services_dock.tscn").instantiate()
 	add_control_to_bottom_panel(_dock, dock_name)
 
 func _remove_docks() -> void:
@@ -34,13 +34,13 @@ func _remove_docks() -> void:
 	_dock.free()
 
 func _add_autoloads() -> void:
-	add_autoload_singleton(PLUGIN_AUTOLOAD, "res://addons/GodotPlayGameServices/scripts/autoloads/godot_play_game_services.gd")
+	add_autoload_singleton(PLUGIN_AUTOLOAD, "res://addons/GodotPlayGamesServices/scripts/autoloads/godot_play_game_services.gd")
 
 func _remove_autoloads() -> void:
 	remove_autoload_singleton(PLUGIN_AUTOLOAD)
 
 class AndroidExportPlugin extends EditorExportPlugin:
-	var _plugin_name = &"GodotPlayGameServices"
+	var _plugin_name = &"GodotPlayGamesServices"
 
 	func _supports_platform(platform):
 		if platform is EditorExportPlatformAndroid:

--- a/plugin/export_scripts_template/godot_play_game_services_dock.tscn
+++ b/plugin/export_scripts_template/godot_play_game_services_dock.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=2 format=3 uid="uid://bx8537vuljblk"]
 
-[ext_resource type="Script" path="res://addons/GodotPlayGameServices/dock.gd" id="1_k0q71"]
+[ext_resource type="Script" path="res://addons/GodotPlayGamesServices/dock.gd" id="1_k0q71"]
 
 [node name="Godot Play Game Services" type="PanelContainer"]
 anchors_preset = 15

--- a/plugin/export_scripts_template/plugin.cfg
+++ b/plugin/export_scripts_template/plugin.cfg
@@ -1,6 +1,6 @@
 [plugin]
 
-name="GodotPlayGameServices"
+name="GodotPlayGamesServices"
 description="A Godot Android plugin for Google Play Game Services"
 author="Jacob Ibáñez Sánchez"
 version="3.2.0"

--- a/plugin/export_scripts_template/scripts/achievements/achievements_client.gd
+++ b/plugin/export_scripts_template/scripts/achievements/achievements_client.gd
@@ -1,4 +1,4 @@
-@icon("res://addons/GodotPlayGameServices/assets/icons/achievements_client.svg")
+@icon("res://addons/GodotPlayGamesServices/assets/icons/achievements_client.svg")
 class_name PlayGamesAchievementsClient extends Node
 ## Client with achievements functionality.
 ##
@@ -28,19 +28,19 @@ func _ready() -> void:
 	_connect_signals()
 
 func _connect_signals() -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.achievementUnlocked.connect(func(is_unlocked: bool, achievement_id: String):
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.achievementUnlocked.connect(func(is_unlocked: bool, achievement_id: String):
 			achievement_unlocked.emit(is_unlocked, achievement_id)
 		)
-		GodotPlayGameServices.android_plugin.achievementsLoaded.connect(func(achievements_json: String):
-			var safe_array := GodotPlayGameServices.json_marshaller.safe_parse_array(achievements_json)
+		GodotPlayGamesServices.android_plugin.achievementsLoaded.connect(func(achievements_json: String):
+			var safe_array := GodotPlayGamesServices.json_marshaller.safe_parse_array(achievements_json)
 			var achievements: Array[PlayGamesAchievement] = []
 			for dictionary: Dictionary in safe_array:
 				achievements.append(PlayGamesAchievement.new(dictionary))
 			
 			achievements_loaded.emit(achievements)
 		)
-		GodotPlayGameServices.android_plugin.achievementRevealed.connect(func(is_revealed: bool, achievement_id: String):
+		GodotPlayGamesServices.android_plugin.achievementRevealed.connect(func(is_revealed: bool, achievement_id: String):
 			achievement_revealed.emit(is_revealed, achievement_id)
 		)
 
@@ -52,8 +52,8 @@ func _connect_signals() -> void:
 ## [param achievement_id]: The achievement id.[br]
 ## [param amount]: The number of steps to increment by. Must be greater than 0.
 func increment_achievement(achievement_id: String, amount: int) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.incrementAchievement(achievement_id, amount)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.incrementAchievement(achievement_id, amount)
 
 ## Use this method and subscribe to the emitted signal to receive the list of the game
 ## achievements.[br]
@@ -65,8 +65,8 @@ func increment_achievement(achievement_id: String, amount: int) -> void:
 ## the first time, and [code]false[/code] in subsequent calls, or when you want
 ## to clear the cache.
 func load_achievements(force_reload: bool) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.loadAchievements(force_reload)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.loadAchievements(force_reload)
 
 ## Use this method to reveal a hidden achievement to the current signed in player. 
 ## If the achievement is already unlocked, this method will have no effect.[br]
@@ -75,14 +75,14 @@ func load_achievements(force_reload: bool) -> void:
 ## [br]
 ## [param achievement_id]: The achievement id.
 func reveal_achievement(achievement_id: String) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.revealAchievement(achievement_id)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.revealAchievement(achievement_id)
 
 ## Use this method to open a new window with the achievements of the game, and 
 ## the progress of the player made so far to unlock those achievements.
 func show_achievements() -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.showAchievements()
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.showAchievements()
 
 ## Immediately unlocks the given achievement for the signed in player. If the 
 ## achievement is secret, it will be revealed to the player.[br]
@@ -91,8 +91,8 @@ func show_achievements() -> void:
 ## [br]
 ## [param achievement_id]: The achievement id.
 func unlock_achievement(achievement_id: String) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.unlockAchievement(achievement_id)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.unlockAchievement(achievement_id)
 
 ## Immediately set the given achievement for the signed in player to have at least the given number of steps completed.[br]
 ## Calling this method when the achievement already has more than the provided steps is a no-op.[br]
@@ -103,5 +103,5 @@ func unlock_achievement(achievement_id: String) -> void:
 ## [param achievement_id]: The achievement id.[br]
 ## [param num_steps]: The number of steps to set the achievement to. Must be greater than 0.
 func set_achievement_steps(achievement_id: String, num_steps: int) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.setAchievementSteps(achievement_id, num_steps)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.setAchievementSteps(achievement_id, num_steps)

--- a/plugin/export_scripts_template/scripts/autoloads/godot_play_game_services.gd
+++ b/plugin/export_scripts_template/scripts/autoloads/godot_play_game_services.gd
@@ -34,11 +34,11 @@ var json_marshaller := JsonMarshaller.new()
 ## Returns [PlayGamesPluginError.OK] if the plugin was initialized properly, or
 ## [PlayGamesPluginError.PLUGIN_NOT_FOUND] otherwise.
 func initialize() -> PlayGamesPluginError:
-	var plugin_name := "GodotPlayGameServices"
+	var plugin_name := "GodotPlayGamesServices"
 	
 	if not android_plugin:
 		if Engine.has_singleton(plugin_name):
-			print("GodotPlayGameServices plugin initialized successfully.")
+			print("GodotPlayGamesServices plugin initialized successfully.")
 			
 			android_plugin = Engine.get_singleton(plugin_name)
 			android_plugin.initialize()
@@ -48,7 +48,7 @@ func initialize() -> PlayGamesPluginError:
 			)
 			return PlayGamesPluginError.OK
 		else:
-			printerr("GodotPlayGameServices not found. Google Play Games Services will not work.")
+			printerr("GodotPlayGamesServices not found. Google Play Games Services will not work.")
 	
 	return PlayGamesPluginError.PLUGIN_NOT_FOUND
 

--- a/plugin/export_scripts_template/scripts/events/events_client.gd
+++ b/plugin/export_scripts_template/scripts/events/events_client.gd
@@ -1,4 +1,4 @@
-@icon("res://addons/GodotPlayGameServices/assets/icons/events_client.svg")
+@icon("res://addons/GodotPlayGamesServices/assets/icons/events_client.svg")
 class_name PlayGamesEventsClient extends Node
 ## Client with events functionality.
 ##
@@ -25,8 +25,8 @@ func _ready() -> void:
 ## [param event_id]: The event ID to increment.[br]
 ## [param increment_amount]: The amount to increment by. Must be greater than or equal to 0.
 func increment_event(event_id: String, increment_amount: int) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.incrementEvent(event_id, increment_amount)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.incrementEvent(event_id, increment_amount)
 
 ## Loads a list of events for the currently signed-in player.[br]
 ## [br]
@@ -35,8 +35,8 @@ func increment_event(event_id: String, increment_amount: int) -> void:
 ## the first time, and [code]false[/code] in subsequent calls, or when you want
 ## to clear the cache.
 func load_events(force_reload: bool) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.loadEvents(force_reload)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.loadEvents(force_reload)
 
 ## Loads a specific list of events for the currently signed-in player.[br]
 ## [br]
@@ -46,13 +46,13 @@ func load_events(force_reload: bool) -> void:
 ## to clear the cache.[br]
 ## [param event_ids]: The IDs of the events to load.
 func load_events_by_ids(force_reload: bool, event_ids: Array[String]) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.loadEventsByIds(force_reload, event_ids)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.loadEventsByIds(force_reload, event_ids)
 
 func _connect_signals() -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.eventsLoaded.connect(_on_events_loaded)
-		GodotPlayGameServices.android_plugin.eventsLoadedByIds.connect(_on_events_loadeds_by_ids)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.eventsLoaded.connect(_on_events_loaded)
+		GodotPlayGamesServices.android_plugin.eventsLoadedByIds.connect(_on_events_loadeds_by_ids)
 
 func _on_events_loaded(json_data: String) -> void:
 	events_loaded.emit(_parse_events(json_data))
@@ -61,7 +61,7 @@ func _on_events_loadeds_by_ids(json_data: String) -> void:
 	events_loaded.emit(_parse_events(json_data))
 
 func _parse_events(json_data: String) -> Array[PlayGamesEvent]:
-	var safe_array := GodotPlayGameServices.json_marshaller.safe_parse_array(json_data)
+	var safe_array := GodotPlayGamesServices.json_marshaller.safe_parse_array(json_data)
 	var events: Array[PlayGamesEvent] = []
 	for dictionary: Dictionary in safe_array:
 		events.append(PlayGamesEvent.new(dictionary))

--- a/plugin/export_scripts_template/scripts/leaderboards/leaderboards_client.gd
+++ b/plugin/export_scripts_template/scripts/leaderboards/leaderboards_client.gd
@@ -1,4 +1,4 @@
-@icon("res://addons/GodotPlayGameServices/assets/icons/leaderboards_client.svg")
+@icon("res://addons/GodotPlayGamesServices/assets/icons/leaderboards_client.svg")
 class_name PlayGamesLeaderboardsClient extends Node
 ## Client with  leaderboards functionality.
 ##
@@ -46,53 +46,53 @@ func _ready() -> void:
 	_connect_signals()
 
 func _connect_signals() -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.scoreSubmitted.connect(func(is_submitted: bool, leaderboard_id: String):
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.scoreSubmitted.connect(func(is_submitted: bool, leaderboard_id: String):
 			score_submitted.emit(is_submitted, leaderboard_id)
 		)
-		GodotPlayGameServices.android_plugin.scoreLoaded.connect(func(leaderboard_id: String, json_data: String):
-			var safe_dictionary := GodotPlayGameServices.json_marshaller.safe_parse_dictionary(json_data)
+		GodotPlayGamesServices.android_plugin.scoreLoaded.connect(func(leaderboard_id: String, json_data: String):
+			var safe_dictionary := GodotPlayGamesServices.json_marshaller.safe_parse_dictionary(json_data)
 			score_loaded.emit(leaderboard_id, PlayGamesLeaderboardScore.new(safe_dictionary))
 		)
-		GodotPlayGameServices.android_plugin.allLeaderboardsLoaded.connect(func(leaderboards_json: String):
-			var safe_array := GodotPlayGameServices.json_marshaller.safe_parse_array(leaderboards_json)
+		GodotPlayGamesServices.android_plugin.allLeaderboardsLoaded.connect(func(leaderboards_json: String):
+			var safe_array := GodotPlayGamesServices.json_marshaller.safe_parse_array(leaderboards_json)
 			var leaderboards: Array[PlayGamesLeaderboard] = []
 			for dictionary: Dictionary in safe_array:
 				leaderboards.append(PlayGamesLeaderboard.new(dictionary))
 			all_leaderboards_loaded.emit(leaderboards)
 		)
-		GodotPlayGameServices.android_plugin.leaderboardLoaded.connect(func(json_data: String):
-			var safe_dictionary := GodotPlayGameServices.json_marshaller.safe_parse_dictionary(json_data)
+		GodotPlayGamesServices.android_plugin.leaderboardLoaded.connect(func(json_data: String):
+			var safe_dictionary := GodotPlayGamesServices.json_marshaller.safe_parse_dictionary(json_data)
 			leaderboard_loaded.emit(PlayGamesLeaderboard.new(safe_dictionary))
 		)
-		GodotPlayGameServices.android_plugin.playerCenteredScoresLoaded.connect(func(leaderboard_id: String, json_data: String):
-			var safe_dictionary := GodotPlayGameServices.json_marshaller.safe_parse_dictionary(json_data)
+		GodotPlayGamesServices.android_plugin.playerCenteredScoresLoaded.connect(func(leaderboard_id: String, json_data: String):
+			var safe_dictionary := GodotPlayGamesServices.json_marshaller.safe_parse_dictionary(json_data)
 			player_centered_scores_loaded.emit(leaderboard_id, PlayGamesLeaderboardScores.new(safe_dictionary))
 		)
-		GodotPlayGameServices.android_plugin.topScoresLoaded.connect(func(leaderboard_id: String, json_data: String):
-			var safe_dictionary := GodotPlayGameServices.json_marshaller.safe_parse_dictionary(json_data)
+		GodotPlayGamesServices.android_plugin.topScoresLoaded.connect(func(leaderboard_id: String, json_data: String):
+			var safe_dictionary := GodotPlayGamesServices.json_marshaller.safe_parse_dictionary(json_data)
 			top_scores_loaded.emit(leaderboard_id, PlayGamesLeaderboardScores.new(safe_dictionary))
 		)
 
 ## Use this method to show all leaderbords for this game in a new screen.
 func show_all_leaderboards() -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.showAllLeaderboards()
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.showAllLeaderboards()
 
 ## Use this method to show a specific leaderboard in a new screen.[br]
 ## [br]
 ## [param leaderboard_id]: The leaderboard id.
 func show_leaderboard(leaderboard_id: String) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.showLeaderboard(leaderboard_id)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.showLeaderboard(leaderboard_id)
 
 ## Use this method to show a specific leaderboard for a given time span in a new screen.[br]
 ## [br]
 ## [param leaderboard_id]: The leaderboard id.[br]
 ## [param time_span]: The time span for the leaderboard. See the [enum TimeSpan] enum.
 func show_leaderboard_for_time_span(leaderboard_id: String, time_span: PlayGamesLeaderboardVariant.TimeSpan) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.showLeaderboardForTimeSpan(leaderboard_id, time_span)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.showLeaderboardForTimeSpan(leaderboard_id, time_span)
 
 ## Use this method to show a specific leaderboard for a given time span and 
 ## collection type in a new screen.[br]
@@ -105,8 +105,8 @@ func show_leaderboard_for_time_span_and_collection(
 	time_span: PlayGamesLeaderboardVariant.TimeSpan,
 	collection: PlayGamesLeaderboardVariant.Collection
 ) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.showLeaderboardForTimeSpanAndCollection(leaderboard_id, time_span, collection)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.showLeaderboardForTimeSpanAndCollection(leaderboard_id, time_span, collection)
 
 ## Submits the score to the leaderboard for the currently signed in player. The score 
 ## is ignored if it is worse (as defined by the leaderboard configuration) than a previously
@@ -117,8 +117,8 @@ func show_leaderboard_for_time_span_and_collection(
 ## [param leaderboard_id]: The leaderboard id.[br]
 ## [param score]: The raw score value.
 func submit_score(leaderboard_id: String, score: int) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.submitScore(leaderboard_id, score)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.submitScore(leaderboard_id, score)
 
 ## Use this method and subscribe to the emitted signal to receive the score of the
 ## currently signed in player for the specified leaderboard, time span, and collection.[br]
@@ -133,8 +133,8 @@ func load_player_score(
 	time_span: PlayGamesLeaderboardVariant.TimeSpan,
 	collection: PlayGamesLeaderboardVariant.Collection
 ) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.loadPlayerScore(leaderboard_id, time_span, collection)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.loadPlayerScore(leaderboard_id, time_span, collection)
 
 ## Use this method and subscribe to the emitted signal to receive the list of the game
 ## leaderboards.[br]
@@ -146,8 +146,8 @@ func load_player_score(
 ## the first time, and [code]false[/code] in subsequent calls, or when you want
 ## to clear the cache.
 func load_all_leaderboards(force_reload: bool) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.loadAllLeaderboards(force_reload)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.loadAllLeaderboards(force_reload)
 
 ## Use this method and subscribe to the emitted signal to receive a leaderboard.[br]
 ## [br]
@@ -159,8 +159,8 @@ func load_all_leaderboards(force_reload: bool) -> void:
 ## the first time, and [code]false[/code] in subsequent calls, or when you want
 ## to clear the cache.
 func load_leaderboard(leaderboard_id: String, force_reload: bool) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.loadLeaderboard(leaderboard_id, force_reload)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.loadLeaderboard(leaderboard_id, force_reload)
 
 ## Use this method and subscribe to the emitted signal to receive an object containing
 ## the selected leaderboard and an array of scores for that leaderboard, centered in the
@@ -183,8 +183,8 @@ func load_player_centered_scores(
 	max_results: int,
 	force_reload: bool
 ) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.loadPlayerCenteredScores(
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.loadPlayerCenteredScores(
 			leaderboard_id,
 			time_span,
 			collection,
@@ -212,8 +212,8 @@ func load_top_scores(
 	max_results: int,
 	force_reload: bool
 ) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.loadTopScores(
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.loadTopScores(
 			leaderboard_id,
 			time_span,
 			collection,

--- a/plugin/export_scripts_template/scripts/players/players_client.gd
+++ b/plugin/export_scripts_template/scripts/players/players_client.gd
@@ -1,4 +1,4 @@
-@icon("res://addons/GodotPlayGameServices/assets/icons/players_client.svg")
+@icon("res://addons/GodotPlayGamesServices/assets/icons/players_client.svg")
 class_name PlayGamesPlayersClient extends Node
 ## Client with player functionality.
 ##
@@ -27,21 +27,21 @@ func _ready() -> void:
 	_connect_signals()
 
 func _connect_signals() -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.friendsLoaded.connect(func(friends_json: String):
-			var safe_array := GodotPlayGameServices.json_marshaller.safe_parse_array(friends_json)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.friendsLoaded.connect(func(friends_json: String):
+			var safe_array := GodotPlayGamesServices.json_marshaller.safe_parse_array(friends_json)
 			var friends: Array[PlayGamesPlayer] = []
 			for dictionary: Dictionary in safe_array:
 				friends.append(PlayGamesPlayer.new(dictionary))
 			
 			friends_loaded.emit(friends)
 		)
-		GodotPlayGameServices.android_plugin.playerSearched.connect(func(friend_json: String):
-			var safe_dictionary := GodotPlayGameServices.json_marshaller.safe_parse_dictionary(friend_json)
+		GodotPlayGamesServices.android_plugin.playerSearched.connect(func(friend_json: String):
+			var safe_dictionary := GodotPlayGamesServices.json_marshaller.safe_parse_dictionary(friend_json)
 			player_searched.emit(PlayGamesPlayer.new(safe_dictionary))
 		)
-		GodotPlayGameServices.android_plugin.currentPlayerLoaded.connect(func(friend_json: String):
-			var safe_dictionary := GodotPlayGameServices.json_marshaller.safe_parse_dictionary(friend_json)
+		GodotPlayGamesServices.android_plugin.currentPlayerLoaded.connect(func(friend_json: String):
+			var safe_dictionary := GodotPlayGamesServices.json_marshaller.safe_parse_dictionary(friend_json)
 			current_player_loaded.emit(PlayGamesPlayer.new(safe_dictionary))
 		)
 
@@ -59,8 +59,8 @@ func _connect_signals() -> void:
 ## list, and this is set to true, a new window will open asking the user for permission 
 ## to their friends list.
 func load_friends(page_size: int, force_reload: bool, ask_for_permission: bool) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.loadFriends(
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.loadFriends(
 			page_size,
 			force_reload,
 			ask_for_permission
@@ -71,8 +71,8 @@ func load_friends(page_size: int, force_reload: bool, ask_for_permission: bool) 
 ## [br]
 ## [param other_player_id]: The player ID of the player to compare with.
 func compare_profile(other_player_id: String) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.compareProfile(other_player_id)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.compareProfile(other_player_id)
 
 ## Displays a screen where the user can see a comparison of their own profile
 ## against another player's profile.[br]
@@ -91,8 +91,8 @@ func compare_profile_with_alternative_name_hints(
 	other_player_in_game_name: String,
 	current_player_in_game_name: String
 ) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.compareProfileWithAlternativeNameHints(
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.compareProfileWithAlternativeNameHints(
 			other_player_id,
 			other_player_in_game_name,
 			current_player_in_game_name
@@ -102,8 +102,8 @@ func compare_profile_with_alternative_name_hints(
 ## a player, then the [signal player_searched] signal will be emitted, returning
 ## the selected player.
 func search_player() -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.searchPlayer()
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.searchPlayer()
 
 ## Use this method and subscribe to the emitted signal to receive the currently
 ## signed in player.[br]
@@ -115,5 +115,5 @@ func search_player() -> void:
 ## the first time, and [code]false[/code] in subsequent calls, or when you want
 ## to clear the cache.
 func load_current_player(force_reload: bool) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.loadCurrentPlayer(force_reload)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.loadCurrentPlayer(force_reload)

--- a/plugin/export_scripts_template/scripts/sign_in/sign_in_client.gd
+++ b/plugin/export_scripts_template/scripts/sign_in/sign_in_client.gd
@@ -1,4 +1,4 @@
-@icon("res://addons/GodotPlayGameServices/assets/icons/sign_in_client.svg")
+@icon("res://addons/GodotPlayGamesServices/assets/icons/sign_in_client.svg")
 class_name PlayGamesSignInClient extends Node
 ## Client with sign in functionality.
 ##
@@ -22,11 +22,11 @@ func _ready() -> void:
 	_connect_signals()
 
 func _connect_signals() -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.userAuthenticated.connect(func(is_authenticated: bool):
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.userAuthenticated.connect(func(is_authenticated: bool):
 			user_authenticated.emit(is_authenticated)
 		)
-		GodotPlayGameServices.android_plugin.serverSideAccessRequested.connect(func(token: String):
+		GodotPlayGamesServices.android_plugin.serverSideAccessRequested.connect(func(token: String):
 			server_side_access_requested.emit(token)
 		)
 
@@ -35,15 +35,15 @@ func _connect_signals() -> void:
 ## [br]
 ## The method emits the [signal user_authenticated] signal.
 func is_authenticated() -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.isAuthenticated()
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.isAuthenticated()
 
 ## Use this method to provide a manual way to the user for signing in.[br]
 ## [br]
 ## The method emits the [signal user_authenticated] signal.
 func sign_in() -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.signIn()
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.signIn()
 
 ## Requests server-side access to Play Games Services for the currently signed-in player.
 ## When requested, an authorization code is returned that can be used by your server to exchange
@@ -55,5 +55,5 @@ func sign_in() -> void:
 ## [param force_refresh_token]: If true, when the returned authorization code is exchanged, a refresh
 ## token will be included in addition to an access token.
 func request_server_side_access(server_client_id: String, force_refresh_token: bool) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.requestServerSideAccess(server_client_id, force_refresh_token)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.requestServerSideAccess(server_client_id, force_refresh_token)

--- a/plugin/export_scripts_template/scripts/snapshots/snapshots_client.gd
+++ b/plugin/export_scripts_template/scripts/snapshots/snapshots_client.gd
@@ -1,4 +1,4 @@
-@icon("res://addons/GodotPlayGameServices/assets/icons/snapshots_client.svg")
+@icon("res://addons/GodotPlayGamesServices/assets/icons/snapshots_client.svg")
 class_name PlayGamesSnapshotsClient extends Node
 ## Client with save and load games functionality.
 ##
@@ -29,24 +29,24 @@ signal conflict_emitted(conflict: PlayGamesSnapshotConflict)
 signal snapshots_loaded(snapshots: Array[PlayGamesSnapshotMetadata])
 
 func _ready() -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.gameSaved.connect(
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.gameSaved.connect(
 			func(is_saved: bool, save_data_name: String, save_data_description: String):
 				game_saved.emit(is_saved, save_data_name, save_data_description)
 		)
-		GodotPlayGameServices.android_plugin.gameLoaded.connect(func(json_data: String):
-			var safe_dictionary := GodotPlayGameServices.json_marshaller.safe_parse_dictionary(json_data)
+		GodotPlayGamesServices.android_plugin.gameLoaded.connect(func(json_data: String):
+			var safe_dictionary := GodotPlayGamesServices.json_marshaller.safe_parse_dictionary(json_data)
 			if safe_dictionary.is_empty():
 				game_loaded.emit(null)
 			else:
 				game_loaded.emit(PlayGamesSnapshot.new(safe_dictionary))
 		)
-		GodotPlayGameServices.android_plugin.conflictEmitted.connect(func(json_data: String):
-			var safe_dictionary := GodotPlayGameServices.json_marshaller.safe_parse_dictionary(json_data)
+		GodotPlayGamesServices.android_plugin.conflictEmitted.connect(func(json_data: String):
+			var safe_dictionary := GodotPlayGamesServices.json_marshaller.safe_parse_dictionary(json_data)
 			conflict_emitted.emit(PlayGamesSnapshotConflict.new(safe_dictionary))
 		)
-		GodotPlayGameServices.android_plugin.snapshotsLoaded.connect(func(json_data: String):
-			var safe_array := GodotPlayGameServices.json_marshaller.safe_parse_array(json_data)
+		GodotPlayGamesServices.android_plugin.snapshotsLoaded.connect(func(json_data: String):
+			var safe_array := GodotPlayGamesServices.json_marshaller.safe_parse_array(json_data)
 			var snapshots: Array[PlayGamesSnapshotMetadata] = []
 			for dictionary: Dictionary in safe_array:
 				snapshots.append(PlayGamesSnapshotMetadata.new(dictionary))
@@ -66,8 +66,8 @@ func show_saved_games(
 	allow_delete: bool,
 	max_snapshots: int
 ) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.showSavedGames(title, allow_add_button, allow_delete, max_snapshots)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.showSavedGames(title, allow_add_button, allow_delete, max_snapshots)
 
 ## Saves game data to the Google Cloud.[br]
 ## [br]
@@ -84,8 +84,8 @@ func save_game(
 	played_time_millis: int = 0,
 	progress_value: int = 0,
 ) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.saveGame(file_name, description, save_data, played_time_millis, progress_value)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.saveGame(file_name, description, save_data, played_time_millis, progress_value)
 
 ## Loads game data from the Google Cloud.[br]
 ## [br]
@@ -94,8 +94,8 @@ func save_game(
 ## [param fileName]: The name of the save file. Must be between 1 and 100 non-URL-reserved charactes (a-z, A-Z, 0-9, or the symbols "-", ".", "_", or "~").[br]
 ## [param create_if_not_found]: False by default. If true, the snapshot will be created if one cannot be found.
 func load_game(file_name: String, create_if_not_found := false) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.loadGame(file_name, create_if_not_found)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.loadGame(file_name, create_if_not_found)
 
 ## Loads the list of [SnapshotMetadata] of the current signed in player.[br]
 ## [br]
@@ -106,12 +106,12 @@ func load_game(file_name: String, create_if_not_found := false) -> void:
 ## the first time, and [code]false[/code] in subsequent calls, or when you want
 ## to clear the cache.
 func load_snapshots(force_reload: bool) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.loadSnapshots(force_reload)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.loadSnapshots(force_reload)
 
 ## Deletes a snapshot. This will delete the data of the snapshot locally and on the server.[br]
 ## [br]
 ## [param snapshot_id]: The snapshot identifier.
 func delete_snapshot(snapshot_id: String) -> void:
-	if GodotPlayGameServices.android_plugin:
-		GodotPlayGameServices.android_plugin.deleteSnapshot(snapshot_id)
+	if GodotPlayGamesServices.android_plugin:
+		GodotPlayGamesServices.android_plugin.deleteSnapshot(snapshot_id)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,5 +15,5 @@ dependencyResolutionManagement {
     }
 }
 
-rootProject.name = "GodotPlayGameServices"
+rootProject.name = "GodotPlayGamesServices"
 include(":plugin")


### PR DESCRIPTION
## Summary
- Rename the Godot-facing plugin/autoload identifier from `GodotPlayGameServices` to `GodotPlayGamesServices`.
- Update generated addon paths, demo references, and documentation to use the corrected Play Games Services name consistently.
- Keep the internal Kotlin package namespace unchanged.

Closes #97.

## Verification
- `rg "GodotPlayGameServices" -n .` returns no matches.
- `git diff --check`
- `./gradlew.bat assemble` was attempted, but this local environment does not have an Android SDK configured (`ANDROID_HOME`/`sdk.dir` missing), so Gradle stops before compiling.
