### PR TITLE
feat: add `snapshotDeleted` signal and improve `deleteSnapshot` method

### DIFF
--- a/addons/GodotPlayGameServices/scripts/snapshots/snapshots_client.gd
+++ b/addons/GodotPlayGameServices/scripts/snapshots/snapshots_client.gd
@@ -28,6 +28,12 @@ signal conflict_emitted(conflict: PlayGamesSnapshotConflict)
 ## [param snapshots]: The list of snapshots for the current signed in player.
 signal snapshots_loaded(snapshots: Array[PlayGamesSnapshotMetadata])
 
+## Signal emitted after calling the [method delete_snapshot] method.[br]
+## [br]
+## [param snapshots]: status of delete operation and snapshot id.
+signal on_snapshot_deleted_signal(status: bool, deleted_snapshot_id: String)
+
+
 func _ready() -> void:
 	if GodotPlayGameServices.android_plugin:
 		GodotPlayGameServices.android_plugin.gameSaved.connect(
@@ -51,6 +57,9 @@ func _ready() -> void:
 			for dictionary: Dictionary in safe_array:
 				snapshots.append(PlayGamesSnapshotMetadata.new(dictionary))
 			snapshots_loaded.emit(snapshots)
+		)
+		GodotPlayGameServices.android_plugin.snapshotDeleted.connect(func(status: bool, id: String):
+			on_snapshot_deleted_signal.emit(status, id)
 		)
 
 ## Opens a new window to display the saved games for the current player. If you select

--- a/addons/GodotPlayGameServices/scripts/snapshots/snapshots_client.gd
+++ b/addons/GodotPlayGameServices/scripts/snapshots/snapshots_client.gd
@@ -31,7 +31,7 @@ signal snapshots_loaded(snapshots: Array[PlayGamesSnapshotMetadata])
 ## Signal emitted after calling the [method delete_snapshot] method.[br]
 ## [br]
 ## [param snapshots]: status of delete operation and snapshot id.
-signal on_snapshot_deleted_signal(status: bool, deleted_snapshot_id: String)
+signal snapshot_deleted(status: bool, deleted_snapshot_id: String)
 
 
 func _ready() -> void:
@@ -59,7 +59,7 @@ func _ready() -> void:
 			snapshots_loaded.emit(snapshots)
 		)
 		GodotPlayGameServices.android_plugin.snapshotDeleted.connect(func(status: bool, id: String):
-			on_snapshot_deleted_signal.emit(status, id)
+			snapshot_deleted.emit(status, id)
 		)
 
 ## Opens a new window to display the saved games for the current player. If you select
@@ -119,6 +119,8 @@ func load_snapshots(force_reload: bool) -> void:
 		GodotPlayGameServices.android_plugin.loadSnapshots(force_reload)
 
 ## Deletes a snapshot. This will delete the data of the snapshot locally and on the server.[br]
+## [br]
+## This method emits the [signal snapshot_deleted] signal.[br]
 ## [br]
 ## [param snapshot_id]: The snapshot identifier.
 func delete_snapshot(snapshot_id: String) -> void:

--- a/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/signals/Signals.kt
+++ b/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/signals/Signals.kt
@@ -27,7 +27,7 @@ fun getSignals(): MutableSet<SignalInfo> = mutableSetOf(
     SnapshotSignals.gameLoaded,
     SnapshotSignals.conflictEmitted,
     SnapshotSignals.snapshotsLoaded,
-
+    SnapshotSignals.snapshotDeleted,
     EventsSignals.eventsLoaded,
     EventsSignals.eventsLoadedByIds,
 
@@ -60,7 +60,7 @@ object SignInSignals {
 object AchievementsSignals {
     /**
      * This signal is emitted when calling the [com.jacobibanez.plugin.android.godotplaygameservices.GodotAndroidPlugin.incrementAchievement],
-     * [com.jacobibanez.plugin.android.godotplaygameservices.GodotAndroidPlugin.unlockAchievement] 
+     * [com.jacobibanez.plugin.android.godotplaygameservices.GodotAndroidPlugin.unlockAchievement]
      * or [com.jacobibanez.plugin.android.godotplaygameservices.GodotAndroidPlugin.setAchievementSteps] methods.
      *
      * @return `true` if the achievement is unlocked. `false` otherwise. Also returns the id of the achievement.
@@ -194,6 +194,19 @@ object SnapshotSignals {
      * @return A [List] of [com.google.android.gms.games.snapshot.SnapshotMetadata](https://developers.google.com/android/reference/com/google/android/gms/games/snapshot/SnapshotMetadata).
      */
     val snapshotsLoaded = SignalInfo("snapshotsLoaded", String::class.java)
+
+    /**
+     * This signal is emitted when calling the [deleteSnapshot] method.
+     *
+     * @return
+     * - delete status: success (true or false)
+     * - snapshotId: of deleted snapshot
+     */
+    val snapshotDeleted = SignalInfo(
+        "snapshotDeleted",
+        Boolean::class.javaObjectType,
+        String::class.java
+    )
 }
 
 /**

--- a/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/snapshots/SnapshotsProxy.kt
+++ b/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/snapshots/SnapshotsProxy.kt
@@ -16,6 +16,7 @@ import com.google.android.gms.games.snapshot.SnapshotMetadataChange
 import com.google.gson.Gson
 import com.jacobibanez.plugin.android.godotplaygameservices.BuildConfig.GODOT_PLUGIN_NAME
 import com.jacobibanez.plugin.android.godotplaygameservices.signals.SnapshotSignals.conflictEmitted
+import com.jacobibanez.plugin.android.godotplaygameservices.signals.SnapshotSignals.snapshotDeleted
 import com.jacobibanez.plugin.android.godotplaygameservices.signals.SnapshotSignals.gameLoaded
 import com.jacobibanez.plugin.android.godotplaygameservices.signals.SnapshotSignals.gameSaved
 import com.jacobibanez.plugin.android.godotplaygameservices.signals.SnapshotSignals.snapshotsLoaded
@@ -171,37 +172,48 @@ class SnapshotsProxy(
     }
 
     fun deleteSnapshot(snapshotId: String) {
-        var isDeleted = false
-        snapshotsClient.load(true).addOnSuccessListener { annotatedData ->
-            annotatedData.get()?.let { buffer ->
-                buffer
-                    .toList()
-                    .firstOrNull { it.snapshotId == snapshotId }?.let { snapshotMetadata ->
-                        Log.d(tag, "Deleting snapshot with id $snapshotId")
-                        snapshotsClient.delete(snapshotMetadata).addOnCompleteListener { task ->
-                            if (task.isSuccessful) {
-                                Log.d(
-                                    tag,
-                                    "Snapshot with id $snapshotId deleted successfully."
-                                )
-                                isDeleted = true
-                            } else {
-                                Log.e(
-                                    tag,
-                                    "Failed to delete snapshot with id $snapshotId. Cause: ${task.exception}",
-                                    task.exception
-                                )
-                            }
-                        }
+        Log.d(tag, "Attempting to delete snapshot with id: $snapshotId")
+        snapshotsClient.load(true)
+            .addOnSuccessListener { annotatedData ->
+                annotatedData.get()?.let { buffer ->
+                    val snapshotMetadata = buffer.toList()
+                        .firstOrNull { it.snapshotId == snapshotId }
+
+                    if (snapshotMetadata != null) {
+                        performDelete(snapshotMetadata)
+                    } else {
+                        Log.w(tag, "Snapshot with id $snapshotId not found")
+                        emitDeleteResult(false, snapshotId)
                     }
+                }
             }
-        }
-        if (!isDeleted) {
-            Log.d(tag, "Snapshot with id $snapshotId not found!")
-        }
+            .addOnFailureListener { e ->
+                Log.e(tag, "Failed to load snapshots before delete", e)
+                emitDeleteResult(false, snapshotId)
+            }
     }
 
-    private fun handleConflict(origin: String, conflict: SnapshotConflict?) {
+    private fun performDelete(metadata: SnapshotMetadata) {
+        snapshotsClient.delete(metadata)
+            .addOnSuccessListener { deletedSnapshotId ->
+                Log.d(tag, "Successfully deleted snapshot: $deletedSnapshotId")
+                emitDeleteResult(true, deletedSnapshotId)
+            }
+            .addOnFailureListener { e ->
+                Log.e(tag, "Failed to delete snapshot ${metadata.snapshotId}", e)
+                emitDeleteResult(false, metadata.snapshotId)
+            }
+    }
+
+    private fun emitDeleteResult(success: Boolean, snapshotId: String) {
+        emitSignal(
+            godot,
+            GODOT_PLUGIN_NAME,
+            snapshotDeleted,
+            success,
+            snapshotId
+        )
+    }    private fun handleConflict(origin: String, conflict: SnapshotConflict?) {
         conflict?.let {
             val snapshot = it.snapshot
             val fileName = snapshot.metadata.uniqueName


### PR DESCRIPTION
I improved a bit delete operation.
I got an issue with async execution [here](https://github.com/godot-sdk-integrations/godot-play-game-services/blob/34ec6758b6f5a89969ec6f1bee305b633d77fb7b/plugin/src/main/java/com/jacobibanez/plugin/android/godotplaygameservices/snapshots/SnapshotsProxy.kt#L199):

```kotlin
var isDeleted = false
snapshotsClient.load(true).addOnSuccessListener { ... }
if (!isDeleted) { ... } // <-- exec. immediately and calls in general each time.  
```

<img width="865" height="135" alt="snapshot_deleting_iss" src="https://github.com/user-attachments/assets/0a420dea-c649-4145-81d8-1cfb9f91bf33" />

First it logs `not found` and next `deleted successfully` which is a bit confusing.
So I added new signal `snapshotDeleted` to properly notify the Godot side when a snapshot is deleted with operation status and snapshot id.

Here's my test to delete the same snapshot two times.
<img width="1000" height="384" alt="improved_deleting" src="https://github.com/user-attachments/assets/9ef38c4b-9e9a-4f29-9404-385238f1f33f" />
